### PR TITLE
Added implementation of a countdown latch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Python ignores
 __pycache__
+
+# C ignores
+c/**/build

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(utils)
+
+set(TEST_SOURCES
+    ${CMAKE_SOURCE_DIR}/src/countdownlatch.c
+    ${CMAKE_SOURCE_DIR}/test/test_countdownlatch.c
+)
+
+add_executable(test ${TEST_SOURCES})
+
+target_include_directories(
+    test PUBLIC ${PROJECT_SOURCE_DIR}/src
+)
+
+target_link_libraries(
+    test PRIVATE pthread
+)

--- a/c/src/countdownlatch.c
+++ b/c/src/countdownlatch.c
@@ -1,0 +1,122 @@
+/**
+ * @file countdownlatch.c
+ *
+ * Copyright (c) 2019 Jarosław Wierzbicki
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <countdownlatch.h>
+
+#include <errno.h>
+#include <pthread.h>
+
+int countdownlatch_init(countdownlatch_t *cdl, unsigned int count)
+{
+    if (cdl == NULL) {
+        return -EINVAL;
+    }
+
+    int ret;
+
+    ret = pthread_mutex_init(&cdl->mutex, NULL);
+    if (ret != 0)
+        return ret;
+
+    ret = pthread_cond_init(&cdl->cond, NULL);
+    if (ret != 0) {
+        pthread_mutex_destroy(&cdl->mutex);
+        return ret;
+    }
+
+    cdl->count = count;
+
+    return 0;
+}
+
+int countdownlatch_destroy(countdownlatch_t *cdl)
+{
+    cdl->count = 0;
+
+    pthread_cond_destroy(&cdl->cond);
+    pthread_mutex_destroy(&cdl->mutex);
+
+    return 0;
+}
+
+int countdownlatch_await(countdownlatch_t *cdl)
+{
+    pthread_mutex_lock(&cdl->mutex);
+
+    while (cdl->count > 0)
+        pthread_cond_wait(&cdl->cond, &cdl->mutex);
+
+    pthread_mutex_unlock(&cdl->mutex);
+
+    return 0;
+}
+
+int countdownlatch_await_timeout(countdownlatch_t *cdl,
+                                 const struct timespec *timeout)
+{
+    int ret;
+
+    pthread_mutex_lock(&cdl->mutex);
+
+    while (cdl->count > 0) {
+        ret = pthread_cond_timedwait(&cdl->cond, &cdl->mutex, timeout);
+        if (ret == ETIMEDOUT)
+            break;
+    }
+
+    pthread_mutex_unlock(&cdl->mutex);
+
+    return ret;
+}
+
+int countdownlatch_countdown(countdownlatch_t *cdl)
+{
+    int ret = EFAULT;
+
+    pthread_mutex_lock(&cdl->mutex);
+
+    if (cdl->count == 0) {
+        goto unlock_;
+    }
+
+    if (--cdl->count == 0) {
+        pthread_cond_broadcast(&cdl->cond);
+    }
+
+    ret = 0;
+
+unlock_:
+    pthread_mutex_unlock(&cdl->mutex);
+
+    return ret;
+}
+
+unsigned int countdownlatch_getcount(countdownlatch_t *cdl)
+{
+    pthread_mutex_lock(&cdl->mutex);
+    unsigned int count = cdl->count;
+    pthread_mutex_unlock(&cdl->mutex);
+
+    return count;
+}

--- a/c/src/countdownlatch.h
+++ b/c/src/countdownlatch.h
@@ -1,0 +1,87 @@
+/**
+ * @file countdownlatch.h
+ *
+ * Copyright (c) 2019 Jarosław Wierzbicki
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <pthread.h>
+
+typedef struct countdownlatch {
+    unsigned int count;
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+} countdownlatch_t;
+
+/** Static initializer for the countdown latch.
+ * 
+ * @param[in] count the number of times countdownlatch_countdown() has to be
+ *            invoked before thread calling countdownlatch_await() unblocks
+ */
+#define COUNTDOWNLATCH_INITIALIZER(count) \
+    {count, PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER}
+
+/** Initialises countdownlatch and sets the given countdown value.
+ *
+ * @param[in] cdl pointer to the countdownlatch object
+ * @param[in] count the number of times countdownlatch_countdown() has to be
+ *            invoked before thread calling countdownlatch_await() unblocks
+ * @return 0 upon success and error code otherwise
+ */
+int countdownlatch_init(countdownlatch_t *cdl, unsigned int count);
+
+/** Destroys the countdownlatch object
+ *
+ * After this function is cold the object cannot be used anymore.
+ *
+ * @param[in] cdl pointer to the countdownlatch object
+ *
+ * @return 0 upon success and error code otherwise
+ */
+int countdownlatch_destroy(countdownlatch_t *cdl);
+
+/**
+ * @param[in] cdl pointer to the countdownlatch object
+ *
+ * @return 0 upon success and error code otherwise
+ */
+int countdownlatch_await(countdownlatch_t *cdl);
+
+/**
+ * @param[in] cdl pointer to the countdownlatch object
+ *
+ * @return 0 upon success and error code otherwise
+ */
+int countdownlatch_await_timeout(countdownlatch_t *cdl,
+                                 const struct timespec *timeout);
+
+/**
+ * @param[in] cdl pointer to the countdownlatch object
+ *
+ * @return 0 upon success and error code otherwise
+ */
+int countdownlatch_countdown(countdownlatch_t *cdl);
+
+/**
+ * @param[in] cdl pointer to the countdownlatch object
+ *
+ * @return 0 upon success and error code otherwise
+ */
+unsigned int countdownlatch_getcount(countdownlatch_t *cdl);

--- a/c/test/test_countdownlatch.c
+++ b/c/test/test_countdownlatch.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2019 Jarosław Wierzbicki
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <pthread.h>
+#include <countdownlatch.h>
+
+void *_thread(void *arg)
+{
+    countdownlatch_t *cdl = arg;
+
+    printf("[thread] thread started\n");
+
+    unsigned int count = countdownlatch_getcount(cdl);
+    printf("[thread] count = %u\n", count);
+
+    while (count) {
+        printf("[thread] hit any key...\n");
+
+        getchar();
+        countdownlatch_countdown(cdl);
+
+        count = countdownlatch_getcount(cdl);
+        printf("[thread] count = %u\n", count);
+    };
+
+    printf("[thread] thread finished\n");
+
+    return NULL;
+}
+
+int main(void)
+{
+    pthread_t thread;
+    countdownlatch_t cdl, cdl2 = COUNTDOWNLATCH_INITIALIZER(5);
+
+    countdownlatch_init(&cdl, 5);
+
+    // dynamically initialised latch
+
+    pthread_create(&thread, NULL, _thread, &cdl);
+
+    printf("\n[ main ] waiting for dynamically initialised CDL\n");
+    countdownlatch_await(&cdl);
+    printf("[ main ] finished waiting for CDL\n");
+
+    countdownlatch_destroy(&cdl);
+
+    pthread_join(thread, NULL);
+
+    // statically initialised latch
+
+    pthread_create(&thread, NULL, _thread, &cdl2);
+
+    printf("\n[ main ] waiting for statically initialised CDL\n");
+    countdownlatch_await(&cdl2);
+    printf("[ main ] finished waiting for CDL\n");
+
+    countdownlatch_destroy(&cdl2);
+
+    pthread_join(thread, NULL);
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This concurrent construct allows for a thread to wait until a countdown
latch reaches zero. The latch is preset to a given value during
initialisation.